### PR TITLE
録音画面にFiles音声選択を追加しMP3入力を許可

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ WatchMeプラットフォームのiOSアプリケーション。
 > - [AUTHENTICATION.md](./docs/features/AUTHENTICATION.md) - 認証システム詳細（アカウント削除含む）
 > - [PUSH_NOTIFICATION_ARCHITECTURE.md](./docs/features/PUSH_NOTIFICATION_ARCHITECTURE.md) - プッシュ通知
 > - [RECORDING_SPECIFICATION.md](./docs/features/RECORDING_SPECIFICATION.md) - 録音仕様
+> - [VIDEO_TO_AUDIO_FEATURE.md](./docs/features/VIDEO_TO_AUDIO_FEATURE.md) - 動画音声抽出機能
 >
 > **技術仕様**:
 > - [TECHNICAL.md](./docs/technical/TECHNICAL.md) - アーキテクチャ・データベース設計
@@ -59,6 +60,7 @@ WatchMeプラットフォームのiOSアプリケーション。
 | 🔌 **API仕様を確認・変更** | [TECHNICAL.md](./docs/technical/TECHNICAL.md) |
 | 📡 **プッシュ通知の仕組みを理解** | [PUSH_NOTIFICATION_ARCHITECTURE.md](./docs/features/PUSH_NOTIFICATION_ARCHITECTURE.md) |
 | 🎙️ **録音機能の仕様を確認** | [RECORDING_SPECIFICATION.md](./docs/features/RECORDING_SPECIFICATION.md) |
+| 🎬 **動画/ファイル音声から分析したい** | [VIDEO_TO_AUDIO_FEATURE.md](./docs/features/VIDEO_TO_AUDIO_FEATURE.md) |
 | ⚡ **パフォーマンス問題を解決** | [PERFORMANCE.md](./docs/development/PERFORMANCE.md) |
 | 🔄 **リファクタリング計画を確認** | [REFACTORING_PLAN.md](./docs/development/REFACTORING_PLAN.md) |
 | 🎨 **カラーを変更したい** | [COLOR_GUIDE.md](./docs/development/COLOR_GUIDE.md) |
@@ -78,12 +80,29 @@ WatchMeプラットフォームのiOSアプリケーション。
 ### 主要機能
 
 - **手動録音**: アプリ内での音声録音（フォアグラウンドのみ）
+- **動画音声分析**: カメラロール動画から音声を抽出して分析
+- **ファイル音声分析**: Files（このiPhone内/iCloud Drive）で選択した音声ファイルを分析
 - **AI分析**: 音声認識、感情分析、行動パターン検出
 - **マルチデバイス対応**: 1ユーザーが複数の分析対象デバイス（録音デバイス）を管理可能
 - **リアルタイム更新**: プッシュ通知によるデータ自動更新
 - **コメント機能**: 分析対象に対する日別コメント投稿
 - **サンプルデバイス**: 初回体験の向上と事例カタログ
 - **✅ QRコード共有機能**: デバイスをQRコードで他ユーザーと共有（2025-12-06実装完了）
+
+### 録音・分析の入力ソース（2026-03-05更新）
+
+WatchMeの音声分析は、以下の3経路から入力できます。
+
+1. **アプリ内録音（マイク）**
+   - その場で録音して分析へ送信
+2. **カメラロール動画**
+   - 動画から音声を抽出して分析へ送信
+3. **Files内の音声ファイル**
+   - `WAV / M4A / MP3` を選択して分析へ送信（MP3はアプリ内でM4Aへ変換）
+
+**iOS制約**:
+- アプリが端末全体を自動走査することはできません
+- ユーザーがPickerで選択したファイルのみアクセス可能です（例: 「このiPhone内 > ダウンロード」）
 
 ### QRコード共有機能（2025-12-06実装完了）
 
@@ -271,6 +290,9 @@ xcodebuild -scheme ios_watchme_v9 -sdk iphonesimulator build
 | **初期画面** | ウェルカム画面 | `ios_watchme_v9App.swift`（MainAppView） | ロゴと「はじめる」「ログイン」ボタン |
 | **認証フロー** | 統合認証フロー | `AuthFlowView.swift` | オンボーディングとアカウント選択 |
 | **ログイン画面** | ログイン | `LoginView.swift` | メール/パスワードでログイン |
+| **録音モーダル** | 録音/分析ソース選択 | `FullScreenRecordingView.swift` | 手動録音、カメラロール、ファイル選択の起点 |
+| **動画選択画面** | カメラロール動画ピッカー | `VideoPickerView.swift` / `VideoPicker.swift` | 動画選択 → 音声抽出 → アップロード |
+| **ファイル選択画面** | Files音声ピッカー | `AudioFilePickerView.swift` | `WAV / M4A / MP3` を選択してアップロード |
 | **ホーム画面** | ホーム（リアルタイムステータス） | `SimpleDashboardView.swift` | 日別のダッシュボード。気分グラフ、最新のスポット分析（最大3件）、コメント機能を表示 |
 | **分析結果の一覧画面** | 分析結果の一覧 | `SimpleDashboardView.swift`（内部の`AnalysisListView`） | 1日分の全スポット分析を時系列順に表示 |
 | **気分詳細画面** | 気分詳細 | `HomeView.swift` | 気分グラフの詳細と時間ごとの詳細リスト |
@@ -292,6 +314,9 @@ ios_watchme_v9/
 ├── BehaviorGraphView.swift        # 行動グラフ詳細
 ├── EmotionGraphView.swift         # 感情グラフ詳細
 ├── FullScreenRecordingView.swift  # 録音画面（モーダル）
+├── AudioFilePickerView.swift      # Files音声ピッカー（WAV/M4A/MP3）
+├── VideoPickerView.swift          # カメラロール動画→音声抽出フロー
+├── VideoPicker.swift              # カメラロール動画ピッカー（PHPicker）
 ├── AudioBarVisualizerView.swift   # 音声ビジュアライザー
 ├── UserInfoView.swift             # マイページ
 ├── AuthFlowView.swift             # 統合認証フロー

--- a/docs/features/RECORDING_SPECIFICATION.md
+++ b/docs/features/RECORDING_SPECIFICATION.md
@@ -1,7 +1,39 @@
 # 録音機能 仕様書
 
-**最終更新**: 2025-10-30
+**最終更新**: 2026-03-05
 **ステータス**: ✅ **UI刷新完了・安定稼働**
+
+---
+
+## 🆕 2026-03-05 追記（入力ソース拡張）
+
+録音モーダルからの分析入力経路を拡張し、現在は次の3パターンをサポートしています。
+
+1. **手動録音（マイク）**
+2. **カメラロール動画から音声抽出**
+3. **Filesの音声ファイル選択（WAV / M4A / MP3）**
+
+### 追加仕様（Files音声選択）
+
+- UI: `FullScreenRecordingView` で `カメラロール` / `ファイル` の2ボタンを表示
+- Picker: `AudioFilePickerView` で `fileImporter`（`UTType.audio`）を使用
+- 対応形式: `WAV / M4A / MP3`
+- 変換: MP3はアプリ内でM4Aへ変換してからアップロード
+- 共通処理: 既存のアップロードフロー（`UploaderService`）に統合
+
+### iOS制約（重要）
+
+- アプリは端末全体を自動走査できません
+- ユーザーがPickerで選択したファイルのみアクセス可能です
+- 「このiPhone内 > ダウンロード」配下はFiles UIから選択可能です
+
+### 関連ファイル
+
+- `ios_watchme_v9/FullScreenRecordingView.swift`
+- `ios_watchme_v9/AudioFilePickerView.swift`
+- `ios_watchme_v9/VideoPickerView.swift`
+- `ios_watchme_v9/VideoPicker.swift`
+- `ios_watchme_v9/Services/UploaderService.swift`
 
 ---
 
@@ -232,4 +264,3 @@ spikeRandomFactor = 0.6 + sin(spikeIndex * 2.718 + phase * 0.05) * 0.4 + 0.4
 | 録音開始遅延 | 3～8秒 | **即座（0秒）** |
 | アップロード | 100%失敗 | **正常に成功** |
 | エラーハンドリング | 不完全 | **堅牢** |
-

--- a/docs/features/VIDEO_TO_AUDIO_FEATURE.md
+++ b/docs/features/VIDEO_TO_AUDIO_FEATURE.md
@@ -1,6 +1,6 @@
 # 動画から音声抽出機能 - 実装状況と今後の方針
 
-最終更新: 2025-11-23
+最終更新: 2026-03-05
 
 ---
 
@@ -8,6 +8,10 @@
 
 カメラロールの動画から音声を抽出し、WatchMeの分析フローに送信する機能。
 **動画撮影日時をベースに過去の記録として分析**することで、ユーザーが好きなタイミングで分析データを追加できる。
+
+> 補足（2026-03-05）:
+> 録音モーダルから Files の音声ファイル（WAV/M4A/MP3）を直接選択して分析する機能も追加済みです。
+> このドキュメントは「カメラロール動画→音声抽出」の仕様を中心に記載しています。
 
 ---
 
@@ -29,6 +33,7 @@
 ### 実装ファイル
 - `/ios_watchme_v9/ios_watchme_v9/VideoPicker.swift` - カスタムピッカー実装
 - `/ios_watchme_v9/ios_watchme_v9/VideoPickerView.swift` - メイン処理
+- `/ios_watchme_v9/ios_watchme_v9/AudioFilePickerView.swift` - Files音声ピッカー（WAV/M4A/MP3）
 - `/ios_watchme_v9/ios_watchme_v9/ContentView.swift` - FABボタン
 - `/ios_watchme_v9/ios_watchme_v9/Components/FloatingActionButton.swift` - 共通FAB
 - `/projects/watchme/api/vault/app.py` - M4A→WAV変換機能

--- a/ios_watchme_v9/AudioFilePickerView.swift
+++ b/ios_watchme_v9/AudioFilePickerView.swift
@@ -1,0 +1,271 @@
+//
+//  AudioFilePickerView.swift
+//  ios_watchme_v9
+//
+//  Files app audio picker for analysis uploads
+//
+
+import Foundation
+import SwiftUI
+import UniformTypeIdentifiers
+import AVFoundation
+
+struct AudioFilePickerView: View {
+    @Environment(\.dismiss) private var dismiss
+    @EnvironmentObject var deviceManager: DeviceManager
+    @EnvironmentObject var userAccountManager: UserAccountManager
+
+    @State private var showFileImporter = false
+
+    var onAudioProcessingStarted: (() -> Void)?
+
+    var body: some View {
+        Color.clear
+            .onAppear {
+                showFileImporter = true
+            }
+            .fileImporter(
+                isPresented: $showFileImporter,
+                allowedContentTypes: [.audio],
+                allowsMultipleSelection: false
+            ) { result in
+                switch result {
+                case .success(let urls):
+                    guard let selectedURL = urls.first else {
+                        dismiss()
+                        return
+                    }
+
+                    Task {
+                        await handleAudioSelection(fileURL: selectedURL)
+                    }
+                case .failure(let error):
+                    ToastManager.shared.showError(
+                        title: "読み込み失敗",
+                        subtitle: error.localizedDescription
+                    )
+                    dismiss()
+                }
+            }
+    }
+
+    private func handleAudioSelection(fileURL: URL) async {
+        guard !userAccountManager.requireWritePermission() else {
+            await MainActor.run {
+                ToastManager.shared.showError(
+                    title: "ログインが必要です",
+                    subtitle: "この機能を使用するにはログインしてください"
+                )
+                dismiss()
+            }
+            return
+        }
+
+        guard deviceManager.selectedDeviceID != nil else {
+            await MainActor.run {
+                ToastManager.shared.showError(
+                    title: "デバイス連携が必要です",
+                    subtitle: "デバイスを連携してください"
+                )
+                dismiss()
+            }
+            return
+        }
+
+        do {
+            await MainActor.run {
+                onAudioProcessingStarted?()
+                ToastManager.shared.showProgressWithPhase(
+                    phase: "音声ファイルを読み込み中...",
+                    subtitle: nil,
+                    progress: 0.0
+                )
+            }
+
+            let preparedFileURL = try await prepareAudioFileForUpload(from: fileURL)
+
+            await MainActor.run {
+                ToastManager.shared.showProgressWithPhase(
+                    phase: "音声をアップロード中...",
+                    subtitle: preparedFileURL.lastPathComponent,
+                    progress: 0.66
+                )
+            }
+
+            try await uploadAudioFile(preparedFileURL)
+
+            await MainActor.run {
+                ToastManager.shared.showProgressWithPhase(
+                    phase: "音声をアップロード中...",
+                    subtitle: preparedFileURL.lastPathComponent,
+                    progress: 1.0
+                )
+            }
+            try? await Task.sleep(nanoseconds: 300_000_000)
+
+            await MainActor.run {
+                ToastManager.shared.showSuccess(
+                    title: "送信完了",
+                    subtitle: "分析結果をお待ちください"
+                )
+            }
+        } catch {
+            await MainActor.run {
+                ToastManager.shared.showError(
+                    title: "送信失敗",
+                    subtitle: error.localizedDescription
+                )
+            }
+        }
+
+        await MainActor.run {
+            dismiss()
+        }
+    }
+
+    private func prepareAudioFileForUpload(from sourceURL: URL) async throws -> URL {
+        let accessGranted = sourceURL.startAccessingSecurityScopedResource()
+        defer {
+            if accessGranted {
+                sourceURL.stopAccessingSecurityScopedResource()
+            }
+        }
+
+        let detectedExtension = try detectExtension(for: sourceURL)
+        let copiedFileURL = try copyToTemporaryDirectory(sourceURL: sourceURL, fileExtension: detectedExtension)
+
+        await MainActor.run {
+            ToastManager.shared.showProgressWithPhase(
+                phase: "音声ファイルを読み込み中...",
+                subtitle: copiedFileURL.lastPathComponent,
+                progress: 0.33
+            )
+        }
+
+        if detectedExtension == "wav" || detectedExtension == "m4a" {
+            return copiedFileURL
+        }
+
+        if detectedExtension == "mp3" {
+            let convertedURL = try await convertAudioToM4A(inputURL: copiedFileURL)
+            try? FileManager.default.removeItem(at: copiedFileURL)
+            return convertedURL
+        }
+
+        throw AudioFileProcessingError.unsupportedFormat
+    }
+
+    private func copyToTemporaryDirectory(sourceURL: URL, fileExtension: String) throws -> URL {
+        let destinationURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("selected_audio_\(UUID().uuidString).\(fileExtension)")
+
+        try? FileManager.default.removeItem(at: destinationURL)
+
+        do {
+            try FileManager.default.copyItem(at: sourceURL, to: destinationURL)
+        } catch {
+            let data = try Data(contentsOf: sourceURL)
+            try data.write(to: destinationURL, options: .atomic)
+        }
+
+        return destinationURL
+    }
+
+    private func detectExtension(for fileURL: URL) throws -> String {
+        let lowerExt = fileURL.pathExtension.lowercased()
+        if ["wav", "m4a", "mp3"].contains(lowerExt) {
+            return lowerExt
+        }
+
+        if let contentType = try fileURL.resourceValues(forKeys: [.contentTypeKey]).contentType {
+            if let wavType = UTType(filenameExtension: "wav"), contentType.conforms(to: wavType) {
+                return "wav"
+            }
+            if let m4aType = UTType(filenameExtension: "m4a"), contentType.conforms(to: m4aType) {
+                return "m4a"
+            }
+            if let mp3Type = UTType(filenameExtension: "mp3"), contentType.conforms(to: mp3Type) {
+                return "mp3"
+            }
+        }
+
+        throw AudioFileProcessingError.unsupportedFormat
+    }
+
+    private func convertAudioToM4A(inputURL: URL) async throws -> URL {
+        let asset = AVURLAsset(url: inputURL)
+        guard let exportSession = AVAssetExportSession(asset: asset, presetName: AVAssetExportPresetAppleM4A) else {
+            throw AudioFileProcessingError.conversionFailed("変換セッションを作成できませんでした")
+        }
+
+        let outputURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("converted_audio_\(UUID().uuidString).m4a")
+
+        try? FileManager.default.removeItem(at: outputURL)
+
+        exportSession.outputURL = outputURL
+        exportSession.outputFileType = .m4a
+
+        if #available(iOS 18.0, *) {
+            do {
+                try await exportSession.export(to: outputURL, as: .m4a)
+            } catch {
+                throw AudioFileProcessingError.conversionFailed(
+                    error.localizedDescription
+                )
+            }
+        } else {
+            await withCheckedContinuation { continuation in
+                exportSession.exportAsynchronously {
+                    continuation.resume()
+                }
+            }
+
+            guard exportSession.status == .completed else {
+                throw AudioFileProcessingError.conversionFailed(
+                    exportSession.error?.localizedDescription ?? "MP3からM4Aへの変換に失敗しました"
+                )
+            }
+        }
+
+        return outputURL
+    }
+
+    private func uploadAudioFile(_ audioURL: URL) async throws {
+        guard let deviceID = deviceManager.selectedDeviceID,
+              let userID = userAccountManager.effectiveUserId else {
+            throw AudioFileProcessingError.missingRequiredData
+        }
+
+        let uploadRequest = UploadRequest(
+            fileURL: audioURL,
+            fileName: audioURL.lastPathComponent,
+            userID: userID,
+            deviceID: deviceID,
+            recordedAt: Date(),
+            timezone: deviceManager.selectedDeviceTimezone
+        )
+
+        let uploaderService = UploaderService()
+        try await uploaderService.upload(uploadRequest)
+
+        try? FileManager.default.removeItem(at: audioURL)
+    }
+}
+
+enum AudioFileProcessingError: LocalizedError {
+    case unsupportedFormat
+    case conversionFailed(String)
+    case missingRequiredData
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedFormat:
+            return "対応している形式は WAV / M4A / MP3 です"
+        case .conversionFailed(let message):
+            return "音声変換に失敗しました: \(message)"
+        case .missingRequiredData:
+            return "必要な情報が不足しています"
+        }
+    }
+}

--- a/ios_watchme_v9/FullScreenRecordingView.swift
+++ b/ios_watchme_v9/FullScreenRecordingView.swift
@@ -22,7 +22,9 @@ struct FullScreenRecordingView: View {
     @State private var showDeviceRegistrationConfirm = false
     @State private var showSignUpPrompt = false
     @State private var showVideoPicker = false
+    @State private var showAudioFilePicker = false
     @State private var videoProcessingStarted = false  // 動画処理開始フラグ
+    @State private var audioFileProcessingStarted = false  // 音声ファイル処理開始フラグ
 
     // MARK: - Body
     var body: some View {
@@ -72,6 +74,29 @@ struct FullScreenRecordingView: View {
                                 Image(systemName: "photo.on.rectangle")
                                     .font(.system(size: 20, weight: .medium))
                                 Text("カメラロールの動画の音声からも分析できます")
+                                    .font(.system(size: 16, weight: .medium))
+                            }
+                            .foregroundColor(.white)
+                            .padding(.horizontal, 24)
+                            .padding(.vertical, 14)
+                            .background(
+                                Capsule()
+                                    .fill(Color.white.opacity(0.2))
+                                    .overlay(
+                                        Capsule()
+                                            .stroke(Color.white.opacity(0.3), lineWidth: 1)
+                                    )
+                            )
+                        }
+                        .transition(.scale.combined(with: .opacity))
+
+                        Button(action: {
+                            showAudioFilePicker = true
+                        }) {
+                            HStack {
+                                Image(systemName: "folder.fill")
+                                    .font(.system(size: 20, weight: .medium))
+                                Text("ファイルの音声からも分析できます")
                                     .font(.system(size: 16, weight: .medium))
                             }
                             .foregroundColor(.white)
@@ -147,8 +172,21 @@ struct FullScreenRecordingView: View {
                 .environmentObject(userAccountManager)
                 .environmentObject(store)
         }
+        .sheet(isPresented: $showAudioFilePicker) {
+            AudioFilePickerView(onAudioProcessingStarted: {
+                audioFileProcessingStarted = true
+            })
+            .environmentObject(deviceManager)
+            .environmentObject(userAccountManager)
+        }
         .onChange(of: videoProcessingStarted) { oldValue, newValue in
             // 動画処理が開始されたら録音モーダルを閉じる
+            if newValue {
+                dismiss()
+            }
+        }
+        .onChange(of: audioFileProcessingStarted) { oldValue, newValue in
+            // 音声ファイル処理が開始されたら録音モーダルを閉じる
             if newValue {
                 dismiss()
             }

--- a/ios_watchme_v9/FullScreenRecordingView.swift
+++ b/ios_watchme_v9/FullScreenRecordingView.swift
@@ -67,50 +67,52 @@ struct FullScreenRecordingView: View {
                 VStack(spacing: 20) {
                     // ビデオ選択ボタン（録音していない時のみ表示）
                     if !store.state.isRecording {
-                        Button(action: {
-                            showVideoPicker = true
-                        }) {
-                            HStack {
-                                Image(systemName: "photo.on.rectangle")
-                                    .font(.system(size: 20, weight: .medium))
-                                Text("カメラロールの動画の音声からも分析できます")
-                                    .font(.system(size: 16, weight: .medium))
-                            }
-                            .foregroundColor(.white)
-                            .padding(.horizontal, 24)
-                            .padding(.vertical, 14)
-                            .background(
-                                Capsule()
-                                    .fill(Color.white.opacity(0.2))
-                                    .overlay(
-                                        Capsule()
-                                            .stroke(Color.white.opacity(0.3), lineWidth: 1)
-                                    )
-                            )
-                        }
-                        .transition(.scale.combined(with: .opacity))
+                        VStack(spacing: 12) {
+                            HStack(spacing: 12) {
+                                Button(action: {
+                                    showVideoPicker = true
+                                }) {
+                                    Text("カメラロール")
+                                        .font(.system(size: 16, weight: .semibold))
+                                        .foregroundColor(.white)
+                                        .frame(maxWidth: .infinity)
+                                        .padding(.vertical, 14)
+                                        .background(
+                                            Capsule()
+                                                .fill(Color.white.opacity(0.2))
+                                                .overlay(
+                                                    Capsule()
+                                                        .stroke(Color.white.opacity(0.3), lineWidth: 1)
+                                                )
+                                        )
+                                }
 
-                        Button(action: {
-                            showAudioFilePicker = true
-                        }) {
-                            HStack {
-                                Image(systemName: "folder.fill")
-                                    .font(.system(size: 20, weight: .medium))
-                                Text("ファイルの音声からも分析できます")
-                                    .font(.system(size: 16, weight: .medium))
+                                Button(action: {
+                                    showAudioFilePicker = true
+                                }) {
+                                    Text("ファイル")
+                                        .font(.system(size: 16, weight: .semibold))
+                                        .foregroundColor(.white)
+                                        .frame(maxWidth: .infinity)
+                                        .padding(.vertical, 14)
+                                        .background(
+                                            Capsule()
+                                                .fill(Color.white.opacity(0.2))
+                                                .overlay(
+                                                    Capsule()
+                                                        .stroke(Color.white.opacity(0.3), lineWidth: 1)
+                                                )
+                                        )
+                                }
                             }
-                            .foregroundColor(.white)
-                            .padding(.horizontal, 24)
-                            .padding(.vertical, 14)
-                            .background(
-                                Capsule()
-                                    .fill(Color.white.opacity(0.2))
-                                    .overlay(
-                                        Capsule()
-                                            .stroke(Color.white.opacity(0.3), lineWidth: 1)
-                                    )
-                            )
+
+                            Text("カメラロールの撮影動画から音声を抽出して分析できます。また、ファイルにある音声ファイルも分析できます。")
+                                .font(.footnote)
+                                .foregroundColor(.white.opacity(0.85))
+                                .multilineTextAlignment(.center)
+                                .padding(.horizontal, 8)
                         }
+                        .padding(.horizontal, 24)
                         .transition(.scale.combined(with: .opacity))
                     }
 

--- a/ios_watchme_v9/Services/UploaderService.swift
+++ b/ios_watchme_v9/Services/UploaderService.swift
@@ -136,9 +136,12 @@ final class UploaderService {
 
         // Determine content type based on file extension
         let contentType: String
-        if request.fileURL.pathExtension.lowercased() == "m4a" {
+        switch request.fileURL.pathExtension.lowercased() {
+        case "m4a":
             contentType = "audio/mp4"
-        } else {
+        case "mp3":
+            contentType = "audio/mpeg"
+        default:
             contentType = "audio/wav"
         }
         body.append("Content-Type: \(contentType)\r\n\r\n".data(using: .utf8)!)

--- a/ios_watchme_v9/SimpleDashboardView.swift
+++ b/ios_watchme_v9/SimpleDashboardView.swift
@@ -74,6 +74,7 @@ struct SimpleDashboardView: View {
 
     // Pull-to-Refresh trigger (simple approach)
     @State private var refreshTrigger = 0
+    @State private var lastHandledPushTimestamp: Date?
 
     // コメント入力用
     @State private var newCommentText = ""
@@ -347,50 +348,13 @@ struct SimpleDashboardView: View {
             updateFilteredData()
         }
         .onChange(of: pushManager.latestUpdate) { oldValue, newValue in
-            // Handle push notification updates from centralized manager
             guard let update = newValue else { return }
-
-            // Only process dashboard refresh notifications
-            guard update.type == .refreshDashboard else { return }
-
-            // Filter: Only process if this view's device matches
-            guard update.deviceId == deviceManager.selectedDeviceID else {
-                print("⚠️ [PUSH] Update ignored (different device)")
-                return
-            }
-
-            // Filter: Only process today's data
-            let calendar = deviceManager.deviceCalendar
-            let today = calendar.startOfDay(for: Date())
-
-            guard calendar.isDate(date, inSameDayAs: today) else {
-                print("⚠️ [PUSH] Update ignored (not today's view)")
-                return
-            }
-
-            print("🔄 [PUSH] Dashboard update received: \(update.deviceId) - \(update.date)")
-
-            // Clear today's cache
-            let formatter = DateFormatter()
-            formatter.dateFormat = "yyyy-MM-dd"
-            formatter.timeZone = deviceManager.getTimezone(for: update.deviceId)
-            let todayString = formatter.string(from: today)
-            let todayCacheKey = "\(update.deviceId)_\(todayString)"
-
-            dataCache.removeValue(forKey: todayCacheKey)
-            cacheKeys.removeAll { $0 == todayCacheKey }
-
-            print("🗑️ [PUSH] Cache cleared: \(todayCacheKey)")
-
-            // Reload data
-            Task {
-                await loadAllData()
-
-                // Show toast after data is loaded
-                await MainActor.run {
-                    ToastManager.shared.showInfo(title: update.message)
-                    print("🍞 [PUSH] Toast displayed: \(update.message)")
-                }
+            processPushUpdateIfNeeded(update)
+        }
+        .onAppear {
+            // Handle pending update when app is opened from notification tap
+            if let update = pushManager.latestUpdate {
+                processPushUpdateIfNeeded(update)
             }
         }
         .sheet(isPresented: $showVibeSheet) {
@@ -456,6 +420,50 @@ struct SimpleDashboardView: View {
                 SpotDetailView(deviceId: deviceId, spotData: spot)
                     .environmentObject(dataManager)
             }
+        }
+    }
+
+    private func processPushUpdateIfNeeded(_ update: PushNotificationManager.PushNotificationUpdate) {
+        // Avoid duplicate handling when onChange and onAppear fire for the same payload
+        if lastHandledPushTimestamp == update.timestamp {
+            return
+        }
+
+        // Only process dashboard refresh notifications
+        guard update.type == .refreshDashboard else { return }
+
+        // Filter: Only process if this view's device matches
+        guard update.deviceId == deviceManager.selectedDeviceID else {
+            print("⚠️ [PUSH] Update ignored (different device)")
+            return
+        }
+
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.timeZone = deviceManager.getTimezone(for: update.deviceId)
+        let viewDateString = formatter.string(from: date)
+
+        // Filter: only this view's date
+        guard viewDateString == update.date else {
+            print("⚠️ [PUSH] Update ignored (different date: view=\(viewDateString), update=\(update.date))")
+            return
+        }
+
+        lastHandledPushTimestamp = update.timestamp
+        print("🔄 [PUSH] Dashboard update received: \(update.deviceId) - \(update.date)")
+
+        let cacheKey = "\(update.deviceId)_\(update.date)"
+        dataCache.removeValue(forKey: cacheKey)
+        cacheKeys.removeAll { $0 == cacheKey }
+        print("🗑️ [PUSH] Cache cleared: \(cacheKey)")
+
+        Task {
+            await loadAllData()
+            await MainActor.run {
+                ToastManager.shared.showInfo(title: update.message)
+                print("🍞 [PUSH] Toast displayed: \(update.message)")
+            }
+            PushNotificationManager.shared.clearUpdate()
         }
     }
     

--- a/ios_watchme_v9/ios_watchme_v9App.swift
+++ b/ios_watchme_v9/ios_watchme_v9App.swift
@@ -462,6 +462,33 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
         return []
     }
 
+    // MARK: - 通知タップ時（バックグラウンド/終了状態）
+
+    func userNotificationCenter(_ center: UNUserNotificationCenter,
+                               didReceive response: UNNotificationResponse) async {
+        let userInfo = response.notification.request.content.userInfo
+
+        print("📲 [PUSH] Notification tapped")
+
+        // Permission check: Authenticated users only
+        guard UserDefaults.standard.string(forKey: "current_user_id") != nil else {
+            print("⚠️ [PUSH] Tap ignored (user not authenticated)")
+            return
+        }
+
+        // Device filter: selected device is known and different -> ignore
+        if let targetDeviceId = userInfo["device_id"] as? String,
+           let selectedDeviceId = UserDefaults.standard.string(forKey: "watchme_selected_device_id"),
+           targetDeviceId != selectedDeviceId {
+            print("⚠️ [PUSH] Tap ignored (different device: target=\(targetDeviceId), selected=\(selectedDeviceId))")
+            return
+        }
+
+        // Delegate to PushNotificationManager so dashboard can refresh on app open
+        let handled = PushNotificationManager.shared.handleAPNsPayload(userInfo)
+        print(handled ? "✅ [PUSH] Tap payload handled" : "⚠️ [PUSH] Tap payload not handled")
+    }
+
     // MARK: - デバイストークン保存
 
     private func saveDeviceToken(_ token: String) {


### PR DESCRIPTION
## 概要
Issue #10 の実装です。

- 録音画面に Files から音声を選択する導線を追加
- `fileImporter`（`UTType.audio`）で音声ファイルを1件選択
- 選択ファイルを一時領域へコピーして既存アップロードフローに接続
- WAV / M4A / MP3 を許可（MP3はM4Aへ変換して送信）
- `UploaderService` に `mp3 -> audio/mpeg` 判定を追加

## 変更ファイル
- `ios_watchme_v9/AudioFilePickerView.swift`
- `ios_watchme_v9/FullScreenRecordingView.swift`
- `ios_watchme_v9/Services/UploaderService.swift`

## 動作確認
- `xcodebuild -scheme ios_watchme_v9 -sdk iphonesimulator build`
  - Build succeeded
  - 既存警告のみ（今回変更外）

## 備考
- iOS制約上、端末全体の自動走査は行わず、ユーザーが Files ピッカーで選択したファイルのみ扱います。
- 「このiPhone内 > ダウンロード」配下は Files UI から選択可能です。